### PR TITLE
Fix for issues 12, 11 and 9.

### DIFF
--- a/src/CryptHash.Net/bin/crypthash/Program.cs
+++ b/src/CryptHash.Net/bin/crypthash/Program.cs
@@ -1,6 +1,6 @@
 ﻿/*
  *      Alessandro Cagliostro, 2019
- *      
+ *
  *      https://github.com/alecgn
  */
 
@@ -183,8 +183,8 @@ namespace CryptHash.Net.CLI
                                     using (var progressBar = new ProgressBar())
                                     {
                                         var aes128 = new AE_AES_128_CBC_HMAC_SHA_256();
-                                        aes128.OnEncryptionProgress += (percentageDone, message) => { progressBar.Report((double)percentageDone / 100); };
-                                        aes128.OnEncryptionMessage += (msg) => { /*Console.WriteLine(msg);*/ progressBar.WriteLine(msg); };
+                                        aes128.OnDecryptionProgress += (percentageDone, message) => { progressBar.Report((double)percentageDone / 100); };
+                                        aes128.OnDecryptionMessage += (msg) => { /*Console.WriteLine(msg);*/ progressBar.WriteLine(msg); };
 
                                         aesDecryptionResult = aes128.DecryptFile(decryptOptions.InputToBeDecrypted, decryptOptions.OutputFilePath, decryptOptions.Password, decryptOptions.DeleteEncryptedFile);
                                     }
@@ -195,8 +195,8 @@ namespace CryptHash.Net.CLI
                                     using (var progressBar = new ProgressBar())
                                     {
                                         var aes192 = new AE_AES_192_CBC_HMAC_SHA_384();
-                                        aes192.OnEncryptionProgress += (percentageDone, message) => { progressBar.Report((double)percentageDone / 100); };
-                                        aes192.OnEncryptionMessage += (msg) => { /*Console.WriteLine(msg);*/ progressBar.WriteLine(msg); };
+                                        aes192.OnDecryptionProgress += (percentageDone, message) => { progressBar.Report((double)percentageDone / 100); };
+                                        aes192.OnDecryptionMessage += (msg) => { /*Console.WriteLine(msg);*/ progressBar.WriteLine(msg); };
 
                                         aesDecryptionResult = aes192.DecryptFile(decryptOptions.InputToBeDecrypted, decryptOptions.OutputFilePath, decryptOptions.Password, decryptOptions.DeleteEncryptedFile);
                                     }
@@ -207,8 +207,8 @@ namespace CryptHash.Net.CLI
                                     using (var progressBar = new ProgressBar())
                                     {
                                         var aes256 = new AE_AES_256_CBC_HMAC_SHA_512();
-                                        aes256.OnEncryptionProgress += (percentageDone, message) => { progressBar.Report((double)percentageDone / 100); };
-                                        aes256.OnEncryptionMessage += (msg) => { /*Console.WriteLine(msg);*/ progressBar.WriteLine(msg); };
+                                        aes256.OnDecryptionProgress += (percentageDone, message) => { progressBar.Report((double)percentageDone / 100); };
+                                        aes256.OnDecryptionMessage += (msg) => { /*Console.WriteLine(msg);*/ progressBar.WriteLine(msg); };
 
                                         aesDecryptionResult = aes256.DecryptFile(decryptOptions.InputToBeDecrypted, decryptOptions.OutputFilePath, decryptOptions.Password, decryptOptions.DeleteEncryptedFile);
                                     }

--- a/src/CryptHash.Net/bin/crypthash/Program.cs
+++ b/src/CryptHash.Net/bin/crypthash/Program.cs
@@ -148,7 +148,7 @@ namespace CryptHash.Net.CLI
 
         private static ExitCode RunDecryptOptionsAndReturnExitCode(DecryptOptions decryptOptions)
         {
-            AesEncryptionResult aesDecryptionResult = null;
+            AesDecryptionResult aesDecryptionResult = null;
 
             switch (decryptOptions.InputType.ToLower())
             {

--- a/src/CryptHash.Net/bin/crypthash/Program.cs
+++ b/src/CryptHash.Net/bin/crypthash/Program.cs
@@ -169,7 +169,7 @@ namespace CryptHash.Net.CLI
                                 aesDecryptionResult = new AEAD_AES_256_GCM().DecryptString(decryptOptions.InputToBeDecrypted, decryptOptions.Password, decryptOptions.AssociatedData);
                                 break;
                             default:
-                                aesDecryptionResult = new AesEncryptionResult() { Success = false, Message = $"Unknown algorithm \"{decryptOptions.Algorithm}\"." };
+                                aesDecryptionResult = new AesDecryptionResult() { Success = false, Message = $"Unknown algorithm \"{decryptOptions.Algorithm}\"." };
                                 break;
                         }
                     }
@@ -215,16 +215,16 @@ namespace CryptHash.Net.CLI
                                 }
                                 break;
                             case "aes256gcm":
-                                aesDecryptionResult = new AesEncryptionResult() { Success = false, Message = $"Algorithm \"{decryptOptions.Algorithm}\" currently not available for file decryption." };
+                                aesDecryptionResult = new AesDecryptionResult() { Success = false, Message = $"Algorithm \"{decryptOptions.Algorithm}\" currently not available for file decryption." };
                                 break;
                             default:
-                                aesDecryptionResult = new AesEncryptionResult() { Success = false, Message = $"Unknown algorithm \"{decryptOptions.Algorithm}\"." };
+                                aesDecryptionResult = new AesDecryptionResult() { Success = false, Message = $"Unknown algorithm \"{decryptOptions.Algorithm}\"." };
                                 break;
                         }
                     }
                     break;
                 default:
-                    aesDecryptionResult = new AesEncryptionResult() { Success = false, Message = $"Unknown input type \"{decryptOptions.InputType}\"." };
+                    aesDecryptionResult = new AesDecryptionResult() { Success = false, Message = $"Unknown input type \"{decryptOptions.InputType}\"." };
                     break;
             }
 

--- a/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_128_CBC_HMAC_SHA_256_Tests.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_128_CBC_HMAC_SHA_256_Tests.cs
@@ -37,7 +37,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         public void Test_DecryptString_with_encryption_data_appended()
         {
             var appendEncryptionData = true;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             string errorMessage = "";
 
             var aesEncryptionResult = _aes128cbcHmacSha256.EncryptString(_testString, _password, appendEncryptionDataToOutputString: appendEncryptionData);
@@ -59,7 +59,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         public void Test_DecryptString_without_encryption_data_appended()
         {
             var appendEncryptionData = false;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             string errorMessage = "";
 
             var aesEncryptionResult = _aes128cbcHmacSha256.EncryptString(_testString, _password, appendEncryptionDataToOutputString: appendEncryptionData);
@@ -109,7 +109,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         {
             var testFilePath = Path.GetTempFileName();
             var appendEncryptionData = true;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             var testFileStringContentRead = "";
             string errorMessage = "";
 
@@ -139,7 +139,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         {
             var testFilePath = Path.GetTempFileName();
             var appendEncryptionData = false;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             var testFileStringContentRead = "";
             string errorMessage = "";
 

--- a/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_128_CBC_HMAC_SHA_256_Tests.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_128_CBC_HMAC_SHA_256_Tests.cs
@@ -44,7 +44,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes128cbcHmacSha256.DecryptString(aesEncryptionResult.EncryptedDataBase64String, _password, hasEncryptionDataAppendedInIntputString: appendEncryptionData);
+                aesDecryptionResult = _aes128cbcHmacSha256.DecryptString(aesEncryptionResult.EncryptedDataBase64String, _password, hasEncryptionDataAppendedInInputString: appendEncryptionData);
 
                 if (!aesDecryptionResult.Success)
                     errorMessage = aesDecryptionResult.Message;
@@ -67,7 +67,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
             if (aesEncryptionResult.Success)
             {
                 aesDecryptionResult = _aes128cbcHmacSha256.DecryptString(aesEncryptionResult.EncryptedDataBytes, Encoding.UTF8.GetBytes(_password),
-                    hasEncryptionDataAppendedInIntputString: appendEncryptionData, aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.IV);
+                    hasEncryptionDataAppendedInInputString: appendEncryptionData, aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.IV);
 
                 if (!aesDecryptionResult.Success)
                     errorMessage = aesDecryptionResult.Message;
@@ -119,7 +119,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes128cbcHmacSha256.DecryptFile(testFilePath, testFilePath, _password, false, hasEncryptionDataAppendedInIntputFile: appendEncryptionData);
+                aesDecryptionResult = _aes128cbcHmacSha256.DecryptFile(testFilePath, testFilePath, _password, false, hasEncryptionDataAppendedInInputFile: appendEncryptionData);
 
                 if (aesDecryptionResult.Success)
                 {
@@ -149,7 +149,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes128cbcHmacSha256.DecryptFile(testFilePath, testFilePath, Encoding.UTF8.GetBytes(_password), false, hasEncryptionDataAppendedInIntputFile: appendEncryptionData,
+                aesDecryptionResult = _aes128cbcHmacSha256.DecryptFile(testFilePath, testFilePath, Encoding.UTF8.GetBytes(_password), false, hasEncryptionDataAppendedInInputFile: appendEncryptionData,
                     aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.IV);
 
                 if (aesDecryptionResult.Success)

--- a/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_192_CBC_HMAC_SHA_384_Tests.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_192_CBC_HMAC_SHA_384_Tests.cs
@@ -37,7 +37,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         public void Test_DecryptString_with_encryption_data_appended()
         {
             var appendEncryptionData = true;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             string errorMessage = "";
 
             var aesEncryptionResult = _aes192cbcHmacSha384.EncryptString(_testString, _password, appendEncryptionDataToOutputString: appendEncryptionData);
@@ -59,7 +59,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         public void Test_DecryptString_without_encryption_data_appended()
         {
             var appendEncryptionData = false;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             string errorMessage = "";
 
             var aesEncryptionResult = _aes192cbcHmacSha384.EncryptString(_testString, _password, appendEncryptionDataToOutputString: appendEncryptionData);
@@ -109,7 +109,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         {
             var testFilePath = Path.GetTempFileName();
             var appendEncryptionData = true;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             var testFileStringContentRead = "";
             string errorMessage = "";
 
@@ -139,7 +139,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         {
             var testFilePath = Path.GetTempFileName();
             var appendEncryptionData = false;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             var testFileStringContentRead = "";
             string errorMessage = "";
 

--- a/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_192_CBC_HMAC_SHA_384_Tests.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_192_CBC_HMAC_SHA_384_Tests.cs
@@ -44,7 +44,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes192cbcHmacSha384.DecryptString(aesEncryptionResult.EncryptedDataBase64String, _password, hasEncryptionDataAppendedInIntputString: appendEncryptionData);
+                aesDecryptionResult = _aes192cbcHmacSha384.DecryptString(aesEncryptionResult.EncryptedDataBase64String, _password, hasEncryptionDataAppendedInInputString: appendEncryptionData);
 
                 if (!aesDecryptionResult.Success)
                     errorMessage = aesDecryptionResult.Message;
@@ -67,7 +67,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
             if (aesEncryptionResult.Success)
             {
                 aesDecryptionResult = _aes192cbcHmacSha384.DecryptString(aesEncryptionResult.EncryptedDataBytes, Encoding.UTF8.GetBytes(_password),
-                    hasEncryptionDataAppendedInIntputString: appendEncryptionData, aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.IV);
+                    hasEncryptionDataAppendedInInputString: appendEncryptionData, aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.IV);
 
                 if (!aesDecryptionResult.Success)
                     errorMessage = aesDecryptionResult.Message;
@@ -119,7 +119,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes192cbcHmacSha384.DecryptFile(testFilePath, testFilePath, _password, false, hasEncryptionDataAppendedInIntputFile: appendEncryptionData);
+                aesDecryptionResult = _aes192cbcHmacSha384.DecryptFile(testFilePath, testFilePath, _password, false, hasEncryptionDataAppendedInInputFile: appendEncryptionData);
 
                 if (aesDecryptionResult.Success)
                 {
@@ -149,7 +149,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes192cbcHmacSha384.DecryptFile(testFilePath, testFilePath, Encoding.UTF8.GetBytes(_password), false, hasEncryptionDataAppendedInIntputFile: appendEncryptionData,
+                aesDecryptionResult = _aes192cbcHmacSha384.DecryptFile(testFilePath, testFilePath, Encoding.UTF8.GetBytes(_password), false, hasEncryptionDataAppendedInInputFile: appendEncryptionData,
                     aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.IV);
 
                 if (aesDecryptionResult.Success)

--- a/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_256_CBC_HMAC_SHA_384_Tests.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_256_CBC_HMAC_SHA_384_Tests.cs
@@ -44,7 +44,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes256cbcHmacSha384.DecryptString(aesEncryptionResult.EncryptedDataBase64String, _password, hasEncryptionDataAppendedInIntputString: appendEncryptionData);
+                aesDecryptionResult = _aes256cbcHmacSha384.DecryptString(aesEncryptionResult.EncryptedDataBase64String, _password, hasEncryptionDataAppendedInInputString: appendEncryptionData);
 
                 if (!aesDecryptionResult.Success)
                     errorMessage = aesDecryptionResult.Message;
@@ -67,7 +67,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
             if (aesEncryptionResult.Success)
             {
                 aesDecryptionResult = _aes256cbcHmacSha384.DecryptString(aesEncryptionResult.EncryptedDataBytes, Encoding.UTF8.GetBytes(_password),
-                    hasEncryptionDataAppendedInIntputString: appendEncryptionData, aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.IV);
+                    hasEncryptionDataAppendedInInputString: appendEncryptionData, aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.IV);
 
                 if (!aesDecryptionResult.Success)
                     errorMessage = aesDecryptionResult.Message;
@@ -119,7 +119,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes256cbcHmacSha384.DecryptFile(testFilePath, testFilePath, _password, false, hasEncryptionDataAppendedInIntputFile: appendEncryptionData);
+                aesDecryptionResult = _aes256cbcHmacSha384.DecryptFile(testFilePath, testFilePath, _password, false, hasEncryptionDataAppendedInInputFile: appendEncryptionData);
 
                 if (aesDecryptionResult.Success)
                 {
@@ -149,7 +149,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes256cbcHmacSha384.DecryptFile(testFilePath, testFilePath, Encoding.UTF8.GetBytes(_password), false, hasEncryptionDataAppendedInIntputFile: appendEncryptionData,
+                aesDecryptionResult = _aes256cbcHmacSha384.DecryptFile(testFilePath, testFilePath, Encoding.UTF8.GetBytes(_password), false, hasEncryptionDataAppendedInInputFile: appendEncryptionData,
                     aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.IV);
 
                 if (aesDecryptionResult.Success)

--- a/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_256_CBC_HMAC_SHA_384_Tests.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_256_CBC_HMAC_SHA_384_Tests.cs
@@ -37,7 +37,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         public void Test_DecryptString_with_encryption_data_appended()
         {
             var appendEncryptionData = true;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             string errorMessage = "";
 
             var aesEncryptionResult = _aes256cbcHmacSha384.EncryptString(_testString, _password, appendEncryptionDataToOutputString: appendEncryptionData);
@@ -59,7 +59,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         public void Test_DecryptString_without_encryption_data_appended()
         {
             var appendEncryptionData = false;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             string errorMessage = "";
 
             var aesEncryptionResult = _aes256cbcHmacSha384.EncryptString(_testString, _password, appendEncryptionDataToOutputString: appendEncryptionData);
@@ -109,7 +109,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         {
             var testFilePath = Path.GetTempFileName();
             var appendEncryptionData = true;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             var testFileStringContentRead = "";
             string errorMessage = "";
 
@@ -139,7 +139,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         {
             var testFilePath = Path.GetTempFileName();
             var appendEncryptionData = false;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             var testFileStringContentRead = "";
             string errorMessage = "";
 

--- a/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_256_CBC_HMAC_SHA_512_Tests.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_256_CBC_HMAC_SHA_512_Tests.cs
@@ -44,7 +44,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes256cbcHmacSha512.DecryptString(aesEncryptionResult.EncryptedDataBase64String, _password, hasEncryptionDataAppendedInIntputString: appendEncryptionData);
+                aesDecryptionResult = _aes256cbcHmacSha512.DecryptString(aesEncryptionResult.EncryptedDataBase64String, _password, hasEncryptionDataAppendedInInputString: appendEncryptionData);
 
                 if (!aesDecryptionResult.Success)
                     errorMessage = aesDecryptionResult.Message;
@@ -67,7 +67,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
             if (aesEncryptionResult.Success)
             {
                 aesDecryptionResult = _aes256cbcHmacSha512.DecryptString(aesEncryptionResult.EncryptedDataBytes, Encoding.UTF8.GetBytes(_password),
-                    hasEncryptionDataAppendedInIntputString: appendEncryptionData, aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.IV);
+                    hasEncryptionDataAppendedInInputString: appendEncryptionData, aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.IV);
 
                 if (!aesDecryptionResult.Success)
                     errorMessage = aesDecryptionResult.Message;
@@ -119,7 +119,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes256cbcHmacSha512.DecryptFile(testFilePath, testFilePath, _password, false, hasEncryptionDataAppendedInIntputFile: appendEncryptionData);
+                aesDecryptionResult = _aes256cbcHmacSha512.DecryptFile(testFilePath, testFilePath, _password, false, hasEncryptionDataAppendedInInputFile: appendEncryptionData);
 
                 if (aesDecryptionResult.Success)
                 {
@@ -149,7 +149,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes256cbcHmacSha512.DecryptFile(testFilePath, testFilePath, Encoding.UTF8.GetBytes(_password), false, hasEncryptionDataAppendedInIntputFile: appendEncryptionData,
+                aesDecryptionResult = _aes256cbcHmacSha512.DecryptFile(testFilePath, testFilePath, Encoding.UTF8.GetBytes(_password), false, hasEncryptionDataAppendedInInputFile: appendEncryptionData,
                     aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.IV);
 
                 if (aesDecryptionResult.Success)

--- a/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_256_CBC_HMAC_SHA_512_Tests.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AE/AE_AES_256_CBC_HMAC_SHA_512_Tests.cs
@@ -37,7 +37,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         public void Test_DecryptString_with_encryption_data_appended()
         {
             var appendEncryptionData = true;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             string errorMessage = "";
 
             var aesEncryptionResult = _aes256cbcHmacSha512.EncryptString(_testString, _password, appendEncryptionDataToOutputString: appendEncryptionData);
@@ -59,7 +59,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         public void Test_DecryptString_without_encryption_data_appended()
         {
             var appendEncryptionData = false;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             string errorMessage = "";
 
             var aesEncryptionResult = _aes256cbcHmacSha512.EncryptString(_testString, _password, appendEncryptionDataToOutputString: appendEncryptionData);
@@ -109,7 +109,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         {
             var testFilePath = Path.GetTempFileName();
             var appendEncryptionData = true;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             var testFileStringContentRead = "";
             string errorMessage = "";
 
@@ -139,7 +139,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AE
         {
             var testFilePath = Path.GetTempFileName();
             var appendEncryptionData = false;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             var testFileStringContentRead = "";
             string errorMessage = "";
 

--- a/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AEAD/AEAD_AES_256_GCM_Tests.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AEAD/AEAD_AES_256_GCM_Tests.cs
@@ -70,7 +70,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AEAD
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes256gcm.DecryptString(aesEncryptionResult.EncryptedDataBytes, Encoding.UTF8.GetBytes(_password), null, hasEncryptionDataAppendedInIntputString: appendEncryptionData,
+                aesDecryptionResult = _aes256gcm.DecryptString(aesEncryptionResult.EncryptedDataBytes, Encoding.UTF8.GetBytes(_password), null, hasEncryptionDataAppendedInInputString: appendEncryptionData,
                     aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.Nonce);
 
                 if (!aesDecryptionResult.Success)
@@ -94,7 +94,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AEAD
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes256gcm.DecryptString(aesEncryptionResult.EncryptedDataBytes, Encoding.UTF8.GetBytes(_password), Encoding.UTF8.GetBytes(associatedData), hasEncryptionDataAppendedInIntputString: appendEncryptionData,
+                aesDecryptionResult = _aes256gcm.DecryptString(aesEncryptionResult.EncryptedDataBytes, Encoding.UTF8.GetBytes(_password), Encoding.UTF8.GetBytes(associatedData), hasEncryptionDataAppendedInInputString: appendEncryptionData,
                     aesEncryptionResult.Tag, aesEncryptionResult.Salt, aesEncryptionResult.Nonce);
 
                 if (!aesDecryptionResult.Success)
@@ -118,7 +118,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AEAD
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes256gcm.DecryptString(aesEncryptionResult.EncryptedDataBase64String, _password, associatedData, hasEncryptionDataAppendedInIntputString: appendEncryptionData);
+                aesDecryptionResult = _aes256gcm.DecryptString(aesEncryptionResult.EncryptedDataBase64String, _password, associatedData, hasEncryptionDataAppendedInInputString: appendEncryptionData);
 
                 if (!aesDecryptionResult.Success)
                     errorMessage = aesDecryptionResult.Message;
@@ -141,7 +141,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AEAD
 
             if (aesEncryptionResult.Success)
             {
-                aesDecryptionResult = _aes256gcm.DecryptString(aesEncryptionResult.EncryptedDataBase64String, _password, associatedData, hasEncryptionDataAppendedInIntputString: appendEncryptionData);
+                aesDecryptionResult = _aes256gcm.DecryptString(aesEncryptionResult.EncryptedDataBase64String, _password, associatedData, hasEncryptionDataAppendedInInputString: appendEncryptionData);
 
                 if (!aesDecryptionResult.Success)
                     errorMessage = aesDecryptionResult.Message;

--- a/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AEAD/AEAD_AES_256_GCM_Tests.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net.Tests/Encryption/AES/AEAD/AEAD_AES_256_GCM_Tests.cs
@@ -63,7 +63,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AEAD
         {
             string associatedData = null;
             var appendEncryptionData = false;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             string errorMessage = "";
 
             var aesEncryptionResult = _aes256gcm.EncryptString(_testString, _password, associatedData, appendEncryptionDataToOutputString: appendEncryptionData);
@@ -87,7 +87,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AEAD
         {
             string associatedData = "0f8fad5b-d9cb-469f-a165-70867728950e";
             var appendEncryptionData = false;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             string errorMessage = "";
 
             var aesEncryptionResult = _aes256gcm.EncryptString(_testString, _password, associatedData, appendEncryptionDataToOutputString: appendEncryptionData);
@@ -111,7 +111,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AEAD
         {
             string associatedData = null;
             var appendEncryptionData = true;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             string errorMessage = "";
 
             var aesEncryptionResult = _aes256gcm.EncryptString(_testString, _password, associatedData, appendEncryptionDataToOutputString: appendEncryptionData);
@@ -134,7 +134,7 @@ namespace CryptHash.Net.Tests.Encryption.AES.AEAD
         {
             string associatedData = "0f8fad5b-d9cb-469f-a165-70867728950e";
             var appendEncryptionData = true;
-            var aesDecryptionResult = new AesEncryptionResult();
+            var aesDecryptionResult = new AesDecryptionResult();
             string errorMessage = "";
 
             var aesEncryptionResult = _aes256gcm.EncryptString(_testString, _password, associatedData, appendEncryptionDataToOutputString: appendEncryptionData);

--- a/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AE/AE_AES_128_CBC_HMAC_SHA_256.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AE/AE_AES_128_CBC_HMAC_SHA_256.cs
@@ -215,11 +215,11 @@ namespace CryptHash.Net.Encryption.AES.AE
 
         #region string decryption
 
-        public AesEncryptionResult DecryptString(string base64EncryptedString, string password, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(string base64EncryptedString, string password, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (string.IsNullOrWhiteSpace(base64EncryptedString))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -228,7 +228,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (string.IsNullOrWhiteSpace(password))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -238,14 +238,14 @@ namespace CryptHash.Net.Encryption.AES.AE
             var encryptedStringBytes = Convert.FromBase64String(base64EncryptedString);
             var passwordBytes = Encoding.UTF8.GetBytes(password);
 
-            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInIntputString);
+            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(string base64EncryptedString, SecureString secStrPassword, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(string base64EncryptedString, SecureString secStrPassword, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (string.IsNullOrWhiteSpace(base64EncryptedString))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -254,7 +254,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -264,14 +264,14 @@ namespace CryptHash.Net.Encryption.AES.AE
             var encryptedStringBytes = Convert.FromBase64String(base64EncryptedString);
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
 
-            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInIntputString);
+            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(byte[] encryptedStringBytes, SecureString secStrPassword, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(byte[] encryptedStringBytes, SecureString secStrPassword, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (encryptedStringBytes == null || encryptedStringBytes.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -280,7 +280,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -289,16 +289,16 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
 
-            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInIntputString);
+            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(byte[] encryptedStringBytes, byte[] passwordBytes,
-            bool hasEncryptionDataAppendedInIntputString = true, byte[] sentTag = null,
+        public AesDecryptionResult DecryptString(byte[] encryptedStringBytes, byte[] passwordBytes,
+            bool hasEncryptionDataAppendedInInputString = true, byte[] sentTag = null,
             byte[] salt = null, byte[] IV = null)
         {
             if (encryptedStringBytes == null || encryptedStringBytes.Length == 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -307,18 +307,18 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (passwordBytes == null || passwordBytes.Length == 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
                 };
             }
 
-            if (hasEncryptionDataAppendedInIntputString)
+            if (hasEncryptionDataAppendedInInputString)
             {
                 if (encryptedStringBytes.Length < (_tagBytesLength + _saltBytesLength + _IVBytesLength))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Incorrect data length, string data tampered data tampered with."
@@ -328,7 +328,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             try
             {
-                if (hasEncryptionDataAppendedInIntputString)
+                if (hasEncryptionDataAppendedInInputString)
                 {
                     sentTag = new byte[_tagBytesLength];
                     Array.Copy(encryptedStringBytes, (encryptedStringBytes.Length - _tagBytesLength), sentTag, 0, sentTag.Length);
@@ -343,12 +343,12 @@ namespace CryptHash.Net.Encryption.AES.AE
                 byte[] derivedKey = EncryptionUtils.GetHashedBytesFromPBKDF2(passwordBytes, salt, (_keyBytesLength * 2), _iterationsForPBKDF2);
                 byte[] cryptKey = derivedKey.Take(_keyBytesLength).ToArray();
                 byte[] authKey = derivedKey.Skip(_keyBytesLength).Take(_keyBytesLength).ToArray();
-                var hmacSha256 = EncryptionUtils.ComputeHMACSHA256HashFromDataBytes(authKey, encryptedStringBytes, 0, (hasEncryptionDataAppendedInIntputString ? (encryptedStringBytes.Length - _tagBytesLength) : encryptedStringBytes.Length));
+                var hmacSha256 = EncryptionUtils.ComputeHMACSHA256HashFromDataBytes(authKey, encryptedStringBytes, 0, (hasEncryptionDataAppendedInInputString ? (encryptedStringBytes.Length - _tagBytesLength) : encryptedStringBytes.Length));
                 var calcTag = hmacSha256.Take(_tagBytesLength).ToArray();
 
                 if (!EncryptionUtils.TagsMatch(calcTag, sentTag))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Authentication for string decryption failed, wrong password or data tampered with."
@@ -357,27 +357,27 @@ namespace CryptHash.Net.Encryption.AES.AE
 
                 byte[] encryptedSourceDataStringBytes = null;
 
-                if (hasEncryptionDataAppendedInIntputString)
+                if (hasEncryptionDataAppendedInInputString)
                 {
                     encryptedSourceDataStringBytes = new byte[(encryptedStringBytes.Length - _tagBytesLength - _saltBytesLength - _IVBytesLength)];
                     Array.Copy(encryptedStringBytes, 0, encryptedSourceDataStringBytes, 0, encryptedSourceDataStringBytes.Length);
                 }
 
-                var aesDecriptionResult = base.DecryptWithMemoryStream((hasEncryptionDataAppendedInIntputString ? encryptedSourceDataStringBytes : encryptedStringBytes),
+                var aesDecryptionResult = base.DecryptWithMemoryStream((hasEncryptionDataAppendedInInputString ? encryptedSourceDataStringBytes : encryptedStringBytes),
                     cryptKey, IV, _cipherMode, _paddingMode);
 
-                if (aesDecriptionResult.Success)
+                if (aesDecryptionResult.Success)
                 {
-                    aesDecriptionResult.DecryptedDataString = Encoding.UTF8.GetString(aesDecriptionResult.DecryptedDataBytes);
-                    aesDecriptionResult.Salt = salt;
-                    aesDecriptionResult.Tag = sentTag;
+                    aesDecryptionResult.DecryptedDataString = Encoding.UTF8.GetString(aesDecryptionResult.DecryptedDataBytes);
+                    aesDecryptionResult.Salt = salt;
+                    aesDecryptionResult.Tag = sentTag;
                 }
 
-                return aesDecriptionResult;
+                return aesDecryptionResult;
             }
             catch (Exception ex)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Error while trying to decrypt string:\n{ex.ToString()}"
@@ -491,11 +491,11 @@ namespace CryptHash.Net.Encryption.AES.AE
 
         #region file decryption
 
-        public AesEncryptionResult DecryptFile(string sourceFilePath, string encryptedFilePath, string password, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInIntputFile = true)
+        public AesDecryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, string password, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInInputFile = true)
         {
             if (string.IsNullOrWhiteSpace(password))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -504,14 +504,14 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var passwordBytes = Encoding.UTF8.GetBytes(password);
 
-            return DecryptFile(sourceFilePath, encryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInIntputFile);
+            return DecryptFile(encryptedFilePath, decryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInInputFile);
         }
 
-        public AesEncryptionResult DecryptFile(string sourceFilePath, string encryptedFilePath, SecureString secStrPassword, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInIntputFile = true)
+        public AesDecryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, SecureString secStrPassword, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInInputFile = true)
         {
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -520,15 +520,15 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
 
-            return DecryptFile(sourceFilePath, encryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInIntputFile);
+            return DecryptFile(encryptedFilePath, decryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInInputFile);
         }
 
-        public AesEncryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, byte[] passwordBytes, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInIntputFile = true,
+        public AesDecryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, byte[] passwordBytes, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInInputFile = true,
             byte[] sentTag = null, byte[] salt = null, byte[] IV = null)
         {
             if (!File.Exists(encryptedFilePath))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Encrypted file \"{encryptedFilePath}\" not found."
@@ -542,7 +542,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (passwordBytes == null || passwordBytes.Length == 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -551,11 +551,11 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var encryptedFileSize = new FileInfo(encryptedFilePath).Length;
 
-            if (hasEncryptionDataAppendedInIntputFile)
+            if (hasEncryptionDataAppendedInInputFile)
             {
                 if (encryptedFileSize < (_tagBytesLength + _saltBytesLength + _IVBytesLength))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Incorrect data length, file data tampered with."
@@ -565,7 +565,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             try
             {
-                if (hasEncryptionDataAppendedInIntputFile)
+                if (hasEncryptionDataAppendedInInputFile)
                 {
                     byte[] additionalData = new byte[_IVBytesLength + _saltBytesLength + _tagBytesLength];
                     additionalData = EncryptionUtils.GetBytesFromFile(encryptedFilePath, additionalData.Length, (encryptedFileSize - additionalData.Length));
@@ -583,19 +583,19 @@ namespace CryptHash.Net.Encryption.AES.AE
                 byte[] cryptKey = derivedKey.Take(_keyBytesLength).ToArray();
                 byte[] authKey = derivedKey.Skip(_keyBytesLength).Take(_keyBytesLength).ToArray();
 
-                var hmacSha256 = EncryptionUtils.ComputeHMACSHA256HashFromFile(encryptedFilePath, authKey, 0, (hasEncryptionDataAppendedInIntputFile ? encryptedFileSize - _tagBytesLength : encryptedFileSize));
+                var hmacSha256 = EncryptionUtils.ComputeHMACSHA256HashFromFile(encryptedFilePath, authKey, 0, (hasEncryptionDataAppendedInInputFile ? encryptedFileSize - _tagBytesLength : encryptedFileSize));
                 var calcTag = hmacSha256.Take(_tagBytesLength).ToArray();
 
                 if (!EncryptionUtils.TagsMatch(calcTag, sentTag))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Authentication for file decryption failed, wrong password or data tampered with."
                     };
                 }
 
-                long endPosition = (hasEncryptionDataAppendedInIntputFile ? (encryptedFileSize - _tagBytesLength - _saltBytesLength - _IVBytesLength) : encryptedFileSize);
+                long endPosition = (hasEncryptionDataAppendedInInputFile ? (encryptedFileSize - _tagBytesLength - _saltBytesLength - _IVBytesLength) : encryptedFileSize);
 
                 var aesDecryptionResult = base.DecryptWithFileStream(encryptedFilePath, decryptedFilePath, cryptKey, IV, _cipherMode, _paddingMode, deleteSourceFile, 4, 0, endPosition);
 
@@ -609,7 +609,7 @@ namespace CryptHash.Net.Encryption.AES.AE
             }
             catch (Exception ex)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Error while trying to decrypt file:\n{ex.ToString()}"

--- a/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AE/AE_AES_192_CBC_HMAC_SHA_384.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AE/AE_AES_192_CBC_HMAC_SHA_384.cs
@@ -215,11 +215,11 @@ namespace CryptHash.Net.Encryption.AES.AE
 
         #region string decryption
 
-        public AesEncryptionResult DecryptString(string base64EncryptedString, string password, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(string base64EncryptedString, string password, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (string.IsNullOrWhiteSpace(base64EncryptedString))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -228,7 +228,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (string.IsNullOrWhiteSpace(password))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -238,14 +238,14 @@ namespace CryptHash.Net.Encryption.AES.AE
             var encryptedStringBytes = Convert.FromBase64String(base64EncryptedString);
             var passwordBytes = Encoding.UTF8.GetBytes(password);
 
-            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInIntputString);
+            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(string base64EncryptedString, SecureString secStrPassword, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(string base64EncryptedString, SecureString secStrPassword, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (string.IsNullOrWhiteSpace(base64EncryptedString))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -254,7 +254,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -264,14 +264,14 @@ namespace CryptHash.Net.Encryption.AES.AE
             var encryptedStringBytes = Convert.FromBase64String(base64EncryptedString);
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
 
-            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInIntputString);
+            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(byte[] encryptedStringBytes, SecureString secStrPassword)
+        public AesDecryptionResult DecryptString(byte[] encryptedStringBytes, SecureString secStrPassword)
         {
             if (encryptedStringBytes == null || encryptedStringBytes.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -280,7 +280,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -292,13 +292,13 @@ namespace CryptHash.Net.Encryption.AES.AE
             return DecryptString(encryptedStringBytes, passwordBytes);
         }
 
-        public AesEncryptionResult DecryptString(byte[] encryptedStringBytes, byte[] passwordBytes,
-            bool hasEncryptionDataAppendedInIntputString = true, byte[] sentTag = null,
+        public AesDecryptionResult DecryptString(byte[] encryptedStringBytes, byte[] passwordBytes,
+            bool hasEncryptionDataAppendedInInputString = true, byte[] sentTag = null,
             byte[] salt = null, byte[] IV = null)
         {
             if (encryptedStringBytes == null || encryptedStringBytes.Length == 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -307,18 +307,18 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (passwordBytes == null || passwordBytes.Length == 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
                 };
             }
 
-            if (hasEncryptionDataAppendedInIntputString)
+            if (hasEncryptionDataAppendedInInputString)
             {
                 if (encryptedStringBytes.Length < (_tagBytesLength + _saltBytesLength + _IVBytesLength))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Incorrect data length, string data tampered with."
@@ -328,7 +328,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             try
             {
-                if (hasEncryptionDataAppendedInIntputString)
+                if (hasEncryptionDataAppendedInInputString)
                 {
                     sentTag = new byte[_tagBytesLength];
                     Array.Copy(encryptedStringBytes, (encryptedStringBytes.Length - _tagBytesLength), sentTag, 0, sentTag.Length);
@@ -343,12 +343,12 @@ namespace CryptHash.Net.Encryption.AES.AE
                 byte[] derivedKey = EncryptionUtils.GetHashedBytesFromPBKDF2(passwordBytes, salt, (_keyBytesLength * 2), _iterationsForPBKDF2);
                 byte[] cryptKey = derivedKey.Take(_keyBytesLength).ToArray();
                 byte[] authKey = derivedKey.Skip(_keyBytesLength).Take(_keyBytesLength).ToArray();
-                var hmacSha384 = EncryptionUtils.ComputeHMACSHA384HashFromDataBytes(authKey, encryptedStringBytes, 0, (hasEncryptionDataAppendedInIntputString ? (encryptedStringBytes.Length - _tagBytesLength) : encryptedStringBytes.Length));
+                var hmacSha384 = EncryptionUtils.ComputeHMACSHA384HashFromDataBytes(authKey, encryptedStringBytes, 0, (hasEncryptionDataAppendedInInputString ? (encryptedStringBytes.Length - _tagBytesLength) : encryptedStringBytes.Length));
                 var calcTag = hmacSha384.Take(_tagBytesLength).ToArray();
 
                 if (!EncryptionUtils.TagsMatch(calcTag, sentTag))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Authentication for string decryption failed, wrong password or data tampered with."
@@ -357,27 +357,27 @@ namespace CryptHash.Net.Encryption.AES.AE
 
                 byte[] encryptedSourceDataStringBytes = null;
 
-                if (hasEncryptionDataAppendedInIntputString)
+                if (hasEncryptionDataAppendedInInputString)
                 {
                     encryptedSourceDataStringBytes = new byte[(encryptedStringBytes.Length - _tagBytesLength - _saltBytesLength - _IVBytesLength)];
                     Array.Copy(encryptedStringBytes, 0, encryptedSourceDataStringBytes, 0, encryptedSourceDataStringBytes.Length);
                 }
 
-                var aesDecriptionResult = base.DecryptWithMemoryStream((hasEncryptionDataAppendedInIntputString? encryptedSourceDataStringBytes : encryptedStringBytes), 
+                var aesDecryptionResult = base.DecryptWithMemoryStream((hasEncryptionDataAppendedInInputString? encryptedSourceDataStringBytes : encryptedStringBytes), 
                     cryptKey, IV, _cipherMode, _paddingMode);
 
-                if (aesDecriptionResult.Success)
+                if (aesDecryptionResult.Success)
                 {
-                    aesDecriptionResult.DecryptedDataString = Encoding.UTF8.GetString(aesDecriptionResult.DecryptedDataBytes);
-                    aesDecriptionResult.Salt = salt;
-                    aesDecriptionResult.Tag = sentTag;
+                    aesDecryptionResult.DecryptedDataString = Encoding.UTF8.GetString(aesDecryptionResult.DecryptedDataBytes);
+                    aesDecryptionResult.Salt = salt;
+                    aesDecryptionResult.Tag = sentTag;
                 }
 
-                return aesDecriptionResult;
+                return aesDecryptionResult;
             }
             catch (Exception ex)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Error while trying to decrypt string:\n{ex.ToString()}"
@@ -491,11 +491,11 @@ namespace CryptHash.Net.Encryption.AES.AE
 
         #region file decryption
 
-        public AesEncryptionResult DecryptFile(string sourceFilePath, string encryptedFilePath, string password, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInIntputFile = true)
+        public AesDecryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, string password, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInInputFile = true)
         {
             if (string.IsNullOrWhiteSpace(password))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -504,14 +504,14 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var passwordBytes = Encoding.UTF8.GetBytes(password);
 
-            return DecryptFile(sourceFilePath, encryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInIntputFile);
+            return DecryptFile(encryptedFilePath, decryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInInputFile);
         }
 
-        public AesEncryptionResult DecryptFile(string sourceFilePath, string encryptedFilePath, SecureString secStrPassword, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInIntputFile = true)
+        public AesDecryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, SecureString secStrPassword, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInInputFile = true)
         {
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -520,15 +520,15 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
 
-            return DecryptFile(sourceFilePath, encryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInIntputFile);
+            return DecryptFile(encryptedFilePath, decryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInInputFile);
         }
 
-        public AesEncryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, byte[] passwordBytes, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInIntputFile = true,
+        public AesDecryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, byte[] passwordBytes, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInInputFile = true,
             byte[] sentTag = null, byte[] salt = null, byte[] IV = null)
         {
             if (!File.Exists(encryptedFilePath))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Encrypted file \"{encryptedFilePath}\" not found."
@@ -542,7 +542,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (passwordBytes == null || passwordBytes.Length == 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -551,11 +551,11 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var encryptedFileSize = new FileInfo(encryptedFilePath).Length;
 
-            if (hasEncryptionDataAppendedInIntputFile)
+            if (hasEncryptionDataAppendedInInputFile)
             {
                 if (encryptedFileSize < (_tagBytesLength + _saltBytesLength + _IVBytesLength))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Incorrect data length, file data tampered with."
@@ -565,7 +565,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             try
             {
-                if (hasEncryptionDataAppendedInIntputFile)
+                if (hasEncryptionDataAppendedInInputFile)
                 {
                     byte[] additionalData = new byte[_IVBytesLength + _saltBytesLength + _tagBytesLength];
                     additionalData = EncryptionUtils.GetBytesFromFile(encryptedFilePath, additionalData.Length, (encryptedFileSize - additionalData.Length));
@@ -583,19 +583,19 @@ namespace CryptHash.Net.Encryption.AES.AE
                 byte[] cryptKey = derivedKey.Take(_keyBytesLength).ToArray();
                 byte[] authKey = derivedKey.Skip(_keyBytesLength).Take(_keyBytesLength).ToArray();
 
-                var hmacSha384 = EncryptionUtils.ComputeHMACSHA384HashFromFile(encryptedFilePath, authKey, 0, (hasEncryptionDataAppendedInIntputFile ? encryptedFileSize - _tagBytesLength : encryptedFileSize));
+                var hmacSha384 = EncryptionUtils.ComputeHMACSHA384HashFromFile(encryptedFilePath, authKey, 0, (hasEncryptionDataAppendedInInputFile ? encryptedFileSize - _tagBytesLength : encryptedFileSize));
                 var calcTag = hmacSha384.Take(_tagBytesLength).ToArray();
 
                 if (!EncryptionUtils.TagsMatch(calcTag, sentTag))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Authentication for file decryption failed, wrong password or data tampered with."
                     };
                 }
 
-                long endPosition = (hasEncryptionDataAppendedInIntputFile ? (encryptedFileSize - _tagBytesLength - _saltBytesLength - _IVBytesLength) : encryptedFileSize);
+                long endPosition = (hasEncryptionDataAppendedInInputFile ? (encryptedFileSize - _tagBytesLength - _saltBytesLength - _IVBytesLength) : encryptedFileSize);
 
                 var aesDecryptionResult = base.DecryptWithFileStream(encryptedFilePath, decryptedFilePath, cryptKey, IV, _cipherMode, _paddingMode, deleteSourceFile, 4, 0, endPosition);
 
@@ -609,7 +609,7 @@ namespace CryptHash.Net.Encryption.AES.AE
             }
             catch (Exception ex)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Error while trying to decrypt file:\n{ex.ToString()}"

--- a/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AE/AE_AES_256_CBC_HMAC_SHA_384.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AE/AE_AES_256_CBC_HMAC_SHA_384.cs
@@ -215,11 +215,11 @@ namespace CryptHash.Net.Encryption.AES.AE
 
         #region string decryption
 
-        public AesEncryptionResult DecryptString(string base64EncryptedString, string password, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(string base64EncryptedString, string password, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (string.IsNullOrWhiteSpace(base64EncryptedString))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -228,7 +228,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (string.IsNullOrWhiteSpace(password))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -238,14 +238,14 @@ namespace CryptHash.Net.Encryption.AES.AE
             var encryptedStringBytes = Convert.FromBase64String(base64EncryptedString);
             var passwordBytes = Encoding.UTF8.GetBytes(password);
 
-            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInIntputString);
+            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(string base64EncryptedString, SecureString secStrPassword, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(string base64EncryptedString, SecureString secStrPassword, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (string.IsNullOrWhiteSpace(base64EncryptedString))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -254,7 +254,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -264,14 +264,14 @@ namespace CryptHash.Net.Encryption.AES.AE
             var encryptedStringBytes = Convert.FromBase64String(base64EncryptedString);
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
 
-            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInIntputString);
+            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(byte[] encryptedStringBytes, SecureString secStrPassword, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(byte[] encryptedStringBytes, SecureString secStrPassword, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (encryptedStringBytes == null || encryptedStringBytes.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -280,7 +280,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -289,16 +289,16 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
 
-            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInIntputString);
+            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(byte[] encryptedStringBytes, byte[] passwordBytes,
-            bool hasEncryptionDataAppendedInIntputString = true, byte[] sentTag = null,
+        public AesDecryptionResult DecryptString(byte[] encryptedStringBytes, byte[] passwordBytes,
+            bool hasEncryptionDataAppendedInInputString = true, byte[] sentTag = null,
             byte[] salt = null, byte[] IV = null)
         {
             if (encryptedStringBytes == null || encryptedStringBytes.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -307,18 +307,18 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (passwordBytes == null || passwordBytes.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
                 };
             }
 
-            if (hasEncryptionDataAppendedInIntputString)
+            if (hasEncryptionDataAppendedInInputString)
             {
                 if (encryptedStringBytes.Length < (_tagBytesLength + _saltBytesLength + _IVBytesLength))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Incorrect data length, string data tampered with."
@@ -328,7 +328,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             try
             {
-                if (hasEncryptionDataAppendedInIntputString)
+                if (hasEncryptionDataAppendedInInputString)
                 {
                     sentTag = new byte[_tagBytesLength];
                     Array.Copy(encryptedStringBytes, (encryptedStringBytes.Length - _tagBytesLength), sentTag, 0, sentTag.Length);
@@ -343,12 +343,12 @@ namespace CryptHash.Net.Encryption.AES.AE
                 byte[] derivedKey = EncryptionUtils.GetHashedBytesFromPBKDF2(passwordBytes, salt, (_keyBytesLength * 2), _iterationsForPBKDF2);
                 byte[] cryptKey = derivedKey.Take(_keyBytesLength).ToArray();
                 byte[] authKey = derivedKey.Skip(_keyBytesLength).Take(_keyBytesLength).ToArray();
-                var hmacSha384 = EncryptionUtils.ComputeHMACSHA384HashFromDataBytes(authKey, encryptedStringBytes, 0, (hasEncryptionDataAppendedInIntputString ? (encryptedStringBytes.Length - _tagBytesLength) : encryptedStringBytes.Length));
+                var hmacSha384 = EncryptionUtils.ComputeHMACSHA384HashFromDataBytes(authKey, encryptedStringBytes, 0, (hasEncryptionDataAppendedInInputString ? (encryptedStringBytes.Length - _tagBytesLength) : encryptedStringBytes.Length));
                 var calcTag = hmacSha384.Take(_tagBytesLength).ToArray();
 
                 if (!EncryptionUtils.TagsMatch(calcTag, sentTag))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Authentication for string decryption failed, wrong password or data tampered with."
@@ -357,27 +357,27 @@ namespace CryptHash.Net.Encryption.AES.AE
 
                 byte[] encryptedSourceDataStringBytes = null;
 
-                if (hasEncryptionDataAppendedInIntputString)
+                if (hasEncryptionDataAppendedInInputString)
                 {
                     encryptedSourceDataStringBytes = new byte[(encryptedStringBytes.Length - _tagBytesLength - _saltBytesLength - _IVBytesLength)];
                     Array.Copy(encryptedStringBytes, 0, encryptedSourceDataStringBytes, 0, encryptedSourceDataStringBytes.Length);
                 }
 
-                var aesDecriptionResult = base.DecryptWithMemoryStream((hasEncryptionDataAppendedInIntputString ? encryptedSourceDataStringBytes : encryptedStringBytes),
+                var aesDecryptionResult = base.DecryptWithMemoryStream((hasEncryptionDataAppendedInInputString ? encryptedSourceDataStringBytes : encryptedStringBytes),
                     cryptKey, IV, _cipherMode, _paddingMode);
 
-                if (aesDecriptionResult.Success)
+                if (aesDecryptionResult.Success)
                 {
-                    aesDecriptionResult.DecryptedDataString = Encoding.UTF8.GetString(aesDecriptionResult.DecryptedDataBytes);
-                    aesDecriptionResult.Salt = salt;
-                    aesDecriptionResult.Tag = sentTag;
+                    aesDecryptionResult.DecryptedDataString = Encoding.UTF8.GetString(aesDecryptionResult.DecryptedDataBytes);
+                    aesDecryptionResult.Salt = salt;
+                    aesDecryptionResult.Tag = sentTag;
                 }
 
-                return aesDecriptionResult;
+                return aesDecryptionResult;
             }
             catch (Exception ex)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Error while trying to decrypt string:\n{ex.ToString()}"
@@ -491,11 +491,11 @@ namespace CryptHash.Net.Encryption.AES.AE
 
         #region file decryption
 
-        public AesEncryptionResult DecryptFile(string sourceFilePath, string encryptedFilePath, string password, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInIntputFile = true)
+        public AesDecryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, string password, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInInputFile = true)
         {
             if (string.IsNullOrWhiteSpace(password))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -504,14 +504,14 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var passwordBytes = Encoding.UTF8.GetBytes(password);
 
-            return DecryptFile(sourceFilePath, encryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInIntputFile);
+            return DecryptFile(encryptedFilePath, decryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInInputFile);
         }
 
-        public AesEncryptionResult DecryptFile(string sourceFilePath, string encryptedFilePath, SecureString secStrPassword, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInIntputFile = true)
+        public AesDecryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, SecureString secStrPassword, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInInputFile = true)
         {
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -520,15 +520,15 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
 
-            return DecryptFile(sourceFilePath, encryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInIntputFile);
+            return DecryptFile(encryptedFilePath, decryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInInputFile);
         }
 
-        public AesEncryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, byte[] passwordBytes, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInIntputFile = true,
+        public AesDecryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, byte[] passwordBytes, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInInputFile = true,
             byte[] sentTag = null, byte[] salt = null, byte[] IV = null)
         {
             if (!File.Exists(encryptedFilePath))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Encrypted file \"{encryptedFilePath}\" not found."
@@ -542,7 +542,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (passwordBytes == null || passwordBytes.Length == 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -551,11 +551,11 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var encryptedFileSize = new FileInfo(encryptedFilePath).Length;
 
-            if (hasEncryptionDataAppendedInIntputFile)
+            if (hasEncryptionDataAppendedInInputFile)
             {
                 if (encryptedFileSize < (_tagBytesLength + _saltBytesLength + _IVBytesLength))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Incorrect data length, file data tampered with."
@@ -565,7 +565,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             try
             {
-                if (hasEncryptionDataAppendedInIntputFile)
+                if (hasEncryptionDataAppendedInInputFile)
                 {
                     byte[] additionalData = new byte[_IVBytesLength + _saltBytesLength + _tagBytesLength];
                     additionalData = EncryptionUtils.GetBytesFromFile(encryptedFilePath, additionalData.Length, (encryptedFileSize - additionalData.Length));
@@ -583,19 +583,19 @@ namespace CryptHash.Net.Encryption.AES.AE
                 byte[] cryptKey = derivedKey.Take(_keyBytesLength).ToArray();
                 byte[] authKey = derivedKey.Skip(_keyBytesLength).Take(_keyBytesLength).ToArray();
 
-                var hmacSha384 = EncryptionUtils.ComputeHMACSHA384HashFromFile(encryptedFilePath, authKey, 0, (hasEncryptionDataAppendedInIntputFile ? encryptedFileSize - _tagBytesLength : encryptedFileSize));
+                var hmacSha384 = EncryptionUtils.ComputeHMACSHA384HashFromFile(encryptedFilePath, authKey, 0, (hasEncryptionDataAppendedInInputFile ? encryptedFileSize - _tagBytesLength : encryptedFileSize));
                 var calcTag = hmacSha384.Take(_tagBytesLength).ToArray();
 
                 if (!EncryptionUtils.TagsMatch(calcTag, sentTag))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Authentication for file decryption failed, wrong password or data tampered with."
                     };
                 }
 
-                long endPosition = (hasEncryptionDataAppendedInIntputFile ? (encryptedFileSize - _tagBytesLength - _saltBytesLength - _IVBytesLength) : encryptedFileSize);
+                long endPosition = (hasEncryptionDataAppendedInInputFile ? (encryptedFileSize - _tagBytesLength - _saltBytesLength - _IVBytesLength) : encryptedFileSize);
 
                 var aesDecryptionResult = base.DecryptWithFileStream(encryptedFilePath, decryptedFilePath, cryptKey, IV, _cipherMode, _paddingMode, deleteSourceFile, 4, 0, endPosition);
 
@@ -609,7 +609,7 @@ namespace CryptHash.Net.Encryption.AES.AE
             }
             catch (Exception ex)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Error while trying to decrypt file:\n{ex.ToString()}"

--- a/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AE/AE_AES_256_CBC_HMAC_SHA_512.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AE/AE_AES_256_CBC_HMAC_SHA_512.cs
@@ -215,11 +215,11 @@ namespace CryptHash.Net.Encryption.AES.AE
 
         #region string decryption
 
-        public AesEncryptionResult DecryptString(string base64EncryptedString, string password, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(string base64EncryptedString, string password, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (string.IsNullOrWhiteSpace(base64EncryptedString))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -228,7 +228,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (string.IsNullOrWhiteSpace(password))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -238,14 +238,14 @@ namespace CryptHash.Net.Encryption.AES.AE
             var encryptedStringBytes = Convert.FromBase64String(base64EncryptedString);
             var passwordBytes = Encoding.UTF8.GetBytes(password);
 
-            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInIntputString);
+            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(string base64EncryptedString, SecureString secStrPassword, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(string base64EncryptedString, SecureString secStrPassword, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (string.IsNullOrWhiteSpace(base64EncryptedString))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -254,7 +254,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -264,14 +264,14 @@ namespace CryptHash.Net.Encryption.AES.AE
             var encryptedStringBytes = Convert.FromBase64String(base64EncryptedString);
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
 
-            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInIntputString);
+            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(byte[] encryptedStringBytes, SecureString secStrPassword, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(byte[] encryptedStringBytes, SecureString secStrPassword, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (encryptedStringBytes == null || encryptedStringBytes.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -280,7 +280,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -289,16 +289,16 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
 
-            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInIntputString);
+            return DecryptString(encryptedStringBytes, passwordBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(byte[] encryptedStringBytes, byte[] passwordBytes, 
-            bool hasEncryptionDataAppendedInIntputString = true, byte[] sentTag = null,
+        public AesDecryptionResult DecryptString(byte[] encryptedStringBytes, byte[] passwordBytes, 
+            bool hasEncryptionDataAppendedInInputString = true, byte[] sentTag = null,
             byte[] salt = null, byte[] IV = null)
         {
             if (encryptedStringBytes == null || encryptedStringBytes.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -307,18 +307,18 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (passwordBytes == null || passwordBytes.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
                 };
             }
 
-            if (hasEncryptionDataAppendedInIntputString)
+            if (hasEncryptionDataAppendedInInputString)
             {
                 if (encryptedStringBytes.Length < (_tagBytesLength + _saltBytesLength + _IVBytesLength))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Incorrect data length, string data tampered with."
@@ -328,7 +328,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             try
             {
-                if (hasEncryptionDataAppendedInIntputString)
+                if (hasEncryptionDataAppendedInInputString)
                 {
                     sentTag = new byte[_tagBytesLength];
                     Array.Copy(encryptedStringBytes, (encryptedStringBytes.Length - _tagBytesLength), sentTag, 0, sentTag.Length);
@@ -343,12 +343,12 @@ namespace CryptHash.Net.Encryption.AES.AE
                 byte[] derivedKey = EncryptionUtils.GetHashedBytesFromPBKDF2(passwordBytes, salt, (_keyBytesLength * 2), _iterationsForPBKDF2);
                 byte[] cryptKey = derivedKey.Take(_keyBytesLength).ToArray();
                 byte[] authKey = derivedKey.Skip(_keyBytesLength).Take(_keyBytesLength).ToArray();
-                var hmacSha512 = EncryptionUtils.ComputeHMACSHA512HashFromDataBytes(authKey, encryptedStringBytes, 0, (hasEncryptionDataAppendedInIntputString ? (encryptedStringBytes.Length - _tagBytesLength) : encryptedStringBytes.Length));
+                var hmacSha512 = EncryptionUtils.ComputeHMACSHA512HashFromDataBytes(authKey, encryptedStringBytes, 0, (hasEncryptionDataAppendedInInputString ? (encryptedStringBytes.Length - _tagBytesLength) : encryptedStringBytes.Length));
                 var calcTag = hmacSha512.Take(_tagBytesLength).ToArray();
 
                 if (!EncryptionUtils.TagsMatch(calcTag, sentTag))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Authentication for string decryption failed, wrong password or data tampered with."
@@ -357,27 +357,27 @@ namespace CryptHash.Net.Encryption.AES.AE
 
                 byte[] encryptedSourceDataStringBytes = null;
 
-                if (hasEncryptionDataAppendedInIntputString)
+                if (hasEncryptionDataAppendedInInputString)
                 {
                     encryptedSourceDataStringBytes = new byte[(encryptedStringBytes.Length - _tagBytesLength - _saltBytesLength  - _IVBytesLength)];
                     Array.Copy(encryptedStringBytes, 0, encryptedSourceDataStringBytes, 0, encryptedSourceDataStringBytes.Length);
                 }
 
-                var aesDecriptionResult = base.DecryptWithMemoryStream((hasEncryptionDataAppendedInIntputString ? encryptedSourceDataStringBytes : encryptedStringBytes), 
+                var aesDecryptionResult = base.DecryptWithMemoryStream((hasEncryptionDataAppendedInInputString ? encryptedSourceDataStringBytes : encryptedStringBytes), 
                     cryptKey, IV, _cipherMode, _paddingMode);
 
-                if (aesDecriptionResult.Success)
+                if (aesDecryptionResult.Success)
                 {
-                    aesDecriptionResult.DecryptedDataString = Encoding.UTF8.GetString(aesDecriptionResult.DecryptedDataBytes);
-                    aesDecriptionResult.Salt = salt;
-                    aesDecriptionResult.Tag = sentTag;
+                    aesDecryptionResult.DecryptedDataString = Encoding.UTF8.GetString(aesDecryptionResult.DecryptedDataBytes);
+                    aesDecryptionResult.Salt = salt;
+                    aesDecryptionResult.Tag = sentTag;
                 }
 
-                return aesDecriptionResult;
+                return aesDecryptionResult;
             }
             catch (Exception ex)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Error while trying to decrypt string:\n{ex.ToString()}"
@@ -491,11 +491,11 @@ namespace CryptHash.Net.Encryption.AES.AE
 
         #region file decryption
 
-        public AesEncryptionResult DecryptFile(string sourceFilePath, string encryptedFilePath, string password, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInIntputFile = true)
+        public AesDecryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, string password, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInInputFile = true)
         {
             if (string.IsNullOrWhiteSpace(password))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -504,14 +504,14 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var passwordBytes = Encoding.UTF8.GetBytes(password);
 
-            return DecryptFile(sourceFilePath, encryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInIntputFile);
+            return DecryptFile(encryptedFilePath, decryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInInputFile);
         }
 
-        public AesEncryptionResult DecryptFile(string sourceFilePath, string encryptedFilePath, SecureString secStrPassword, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInIntputFile = true)
+        public AesDecryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, SecureString secStrPassword, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInInputFile = true)
         {
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -520,15 +520,15 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
 
-            return DecryptFile(sourceFilePath, encryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInIntputFile);
+            return DecryptFile(encryptedFilePath, decryptedFilePath, passwordBytes, deleteSourceFile, hasEncryptionDataAppendedInInputFile);
         }
 
-        public AesEncryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, byte[] passwordBytes, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInIntputFile = true,
+        public AesDecryptionResult DecryptFile(string encryptedFilePath, string decryptedFilePath, byte[] passwordBytes, bool deleteSourceFile = false, bool hasEncryptionDataAppendedInInputFile = true,
             byte[] sentTag = null, byte[] salt = null, byte[] IV = null)
         {
             if (!File.Exists(encryptedFilePath))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Encrypted file \"{encryptedFilePath}\" not found."
@@ -542,7 +542,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             if (passwordBytes == null || passwordBytes.Length == 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -551,11 +551,11 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             var encryptedFileSize = new FileInfo(encryptedFilePath).Length;
 
-            if (hasEncryptionDataAppendedInIntputFile)
+            if (hasEncryptionDataAppendedInInputFile)
             {
                 if (encryptedFileSize < (_tagBytesLength + _saltBytesLength + _IVBytesLength))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Incorrect data length, file data tampered with."
@@ -565,7 +565,7 @@ namespace CryptHash.Net.Encryption.AES.AE
 
             try
             {
-                if (hasEncryptionDataAppendedInIntputFile)
+                if (hasEncryptionDataAppendedInInputFile)
                 {
                     byte[] additionalData = new byte[_IVBytesLength + _saltBytesLength + _tagBytesLength];
                     additionalData = EncryptionUtils.GetBytesFromFile(encryptedFilePath, additionalData.Length, (encryptedFileSize - additionalData.Length));
@@ -583,19 +583,19 @@ namespace CryptHash.Net.Encryption.AES.AE
                 byte[] cryptKey = derivedKey.Take(_keyBytesLength).ToArray();
                 byte[] authKey = derivedKey.Skip(_keyBytesLength).Take(_keyBytesLength).ToArray();
 
-                var hmacSha512 = EncryptionUtils.ComputeHMACSHA512HashFromFile(encryptedFilePath, authKey, 0, (hasEncryptionDataAppendedInIntputFile ? encryptedFileSize - _tagBytesLength : encryptedFileSize));
+                var hmacSha512 = EncryptionUtils.ComputeHMACSHA512HashFromFile(encryptedFilePath, authKey, 0, (hasEncryptionDataAppendedInInputFile ? encryptedFileSize - _tagBytesLength : encryptedFileSize));
                 var calcTag = hmacSha512.Take(_tagBytesLength).ToArray();
 
                 if (!EncryptionUtils.TagsMatch(calcTag, sentTag))
                 {
-                    return new AesEncryptionResult()
+                    return new AesDecryptionResult()
                     {
                         Success = false,
                         Message = "Authentication for file decryption failed, wrong password or data tampered with."
                     };
                 }
 
-                long endPosition = (hasEncryptionDataAppendedInIntputFile ? (encryptedFileSize - _tagBytesLength - _saltBytesLength - _IVBytesLength) : encryptedFileSize);
+                long endPosition = (hasEncryptionDataAppendedInInputFile ? (encryptedFileSize - _tagBytesLength - _saltBytesLength - _IVBytesLength) : encryptedFileSize);
 
                 var aesDecryptionResult = base.DecryptWithFileStream(encryptedFilePath, decryptedFilePath, cryptKey, IV, _cipherMode, _paddingMode, deleteSourceFile, 4, 0, endPosition);
 
@@ -609,7 +609,7 @@ namespace CryptHash.Net.Encryption.AES.AE
             }
             catch (Exception ex)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Error while trying to decrypt file:\n{ex.ToString()}"

--- a/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AEAD/AEAD_AES_256_GCM.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AEAD/AEAD_AES_256_GCM.cs
@@ -307,11 +307,11 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
         #region string decryption
 
-        public AesEncryptionResult DecryptString(string base64EncryptedString, string password, string associatedDataString = null, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(string base64EncryptedString, string password, string associatedDataString = null, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (string.IsNullOrEmpty(base64EncryptedString))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -320,7 +320,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
             if (string.IsNullOrEmpty(password))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -331,14 +331,14 @@ namespace CryptHash.Net.Encryption.AES.AEAD
             var passwordBytes = Encoding.UTF8.GetBytes(password);
             var associatedDataBytes = (associatedDataString == null ? null : Encoding.UTF8.GetBytes(associatedDataString));
 
-            return DecryptString(encryptedStringBytes, passwordBytes, associatedDataBytes, hasEncryptionDataAppendedInIntputString);
+            return DecryptString(encryptedStringBytes, passwordBytes, associatedDataBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(string base64EncryptedString, SecureString secStrPassword, string associatedDataString = null, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(string base64EncryptedString, SecureString secStrPassword, string associatedDataString = null, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (string.IsNullOrWhiteSpace(base64EncryptedString))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -347,7 +347,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -358,14 +358,14 @@ namespace CryptHash.Net.Encryption.AES.AEAD
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
             var associatedDataBytes = (associatedDataString == null ? null : Encoding.UTF8.GetBytes(associatedDataString));
 
-            return DecryptString(plainStringBytes, passwordBytes, associatedDataBytes, hasEncryptionDataAppendedInIntputString);
+            return DecryptString(plainStringBytes, passwordBytes, associatedDataBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(byte[] encryptedStringBytes, SecureString secStrPassword, string associatedDataString = null, bool hasEncryptionDataAppendedInIntputString = true)
+        public AesDecryptionResult DecryptString(byte[] encryptedStringBytes, SecureString secStrPassword, string associatedDataString = null, bool hasEncryptionDataAppendedInInputString = true)
         {
             if (encryptedStringBytes == null || encryptedStringBytes.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to encrypt required."
@@ -374,7 +374,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
             if (secStrPassword == null || secStrPassword.Length <= 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Password required."
@@ -384,15 +384,15 @@ namespace CryptHash.Net.Encryption.AES.AEAD
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
             var associatedDataBytes = (associatedDataString == null ? null : Encoding.UTF8.GetBytes(associatedDataString));
 
-            return EncryptString(encryptedStringBytes, passwordBytes, associatedDataBytes, hasEncryptionDataAppendedInIntputString);
+            return EncryptString(encryptedStringBytes, passwordBytes, associatedDataBytes, hasEncryptionDataAppendedInInputString);
         }
 
-        public AesEncryptionResult DecryptString(byte[] encryptedStringBytes, byte[] passwordBytes, byte[] associatedData = null, bool hasEncryptionDataAppendedInIntputString = true,
+        public AesDecryptionResult DecryptString(byte[] encryptedStringBytes, byte[] passwordBytes, byte[] associatedData = null, bool hasEncryptionDataAppendedInInputString = true,
             byte[] tag = null, byte[] salt = null, byte[] nonce = null)
         {
             if (encryptedStringBytes == null || encryptedStringBytes.Length == 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "String to decrypt required."
@@ -401,7 +401,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
             if (encryptedStringBytes.LongLength > _maxInputDataSizeBytes)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Max. encrypted data length cannot be greater than {_maxInputDataSizeBytes} bytes."
@@ -410,7 +410,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
             if (passwordBytes == null)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Password required."
@@ -419,7 +419,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
             if (associatedData != null && associatedData.LongLength > _maxInputAuthDataSizeBytes)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Max. associated data length cannot be greater than {_maxInputAuthDataSizeBytes} bytes."
@@ -430,7 +430,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
             {
                 byte[] encryptedStringBytesWithEncryptionData = null;
 
-                if (hasEncryptionDataAppendedInIntputString)
+                if (hasEncryptionDataAppendedInInputString)
                 {
                     tag = new byte[_tagBytesLength];
                     Array.Copy(encryptedStringBytes, (encryptedStringBytes.Length - _tagBytesLength), tag, 0, tag.Length);
@@ -446,14 +446,14 @@ namespace CryptHash.Net.Encryption.AES.AEAD
                 }
 
                 byte[] derivedKey = EncryptionUtils.GetHashedBytesFromPBKDF2(passwordBytes, salt, _keyBytesLength, _iterationsForPBKDF2, HashAlgorithmName.SHA512);
-                byte[] decryptedData = new byte[(hasEncryptionDataAppendedInIntputString ? encryptedStringBytesWithEncryptionData.Length : encryptedStringBytes.Length)];
+                byte[] decryptedData = new byte[(hasEncryptionDataAppendedInInputString ? encryptedStringBytesWithEncryptionData.Length : encryptedStringBytes.Length)];
 
                 using (var aesGcm = new AesGcm(derivedKey))
                 {
-                    aesGcm.Decrypt(nonce, (hasEncryptionDataAppendedInIntputString ? encryptedStringBytesWithEncryptionData : encryptedStringBytes), tag, decryptedData, associatedData);
+                    aesGcm.Decrypt(nonce, (hasEncryptionDataAppendedInInputString ? encryptedStringBytesWithEncryptionData : encryptedStringBytes), tag, decryptedData, associatedData);
                 }
 
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = true,
                     Message = "Data succesfully decrypted.",
@@ -468,7 +468,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
             }
             catch (Exception ex)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Error while trying to decrypt data:\n{ex.ToString()}"
@@ -476,11 +476,11 @@ namespace CryptHash.Net.Encryption.AES.AEAD
             }
         }
 
-        //public AesEncryptionResult DecryptString(byte[] encryptedStringBytes, byte[] key, byte[] tag, byte[] nonce, byte[] associatedData = null, bool hasEncryptionDataAppendedInIntputString = true)
+        //public AesDecryptionResult DecryptString(byte[] encryptedStringBytes, byte[] key, byte[] tag, byte[] nonce, byte[] associatedData = null, bool hasEncryptionDataAppendedInInputString = true)
         //{
         //    if (encryptedStringBytes == null || encryptedStringBytes.Length == 0)
         //    {
-        //        return new AesEncryptionResult()
+        //        return new AesDecryptionResult()
         //        {
         //            Success = false,
         //            Message = "String to decrypt required."
@@ -489,7 +489,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
         //    if (encryptedStringBytes.LongLength > _maxInputDataSizeBytes)
         //    {
-        //        return new AesEncryptionResult()
+        //        return new AesDecryptionResult()
         //        {
         //            Success = false,
         //            Message = $"Max. encrypted data length cannot be greater than {_maxInputDataSizeBytes} bytes."
@@ -498,7 +498,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
         //    if (key == null)
         //    {
-        //        return new AesEncryptionResult()
+        //        return new AesDecryptionResult()
         //        {
         //            Success = false,
         //            Message = $"Encryption key required."
@@ -507,7 +507,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
         //    if (key.Length != _keyBytesLength)
         //    {
-        //        return new AesEncryptionResult()
+        //        return new AesDecryptionResult()
         //        {
         //            Success = false,
         //            Message = $"Invalid key bit size: ({(key.Length * 8)}). Must be ({_keyBitSize}) bits / ({_keyBytesLength}) bytes."
@@ -516,7 +516,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
         //    if (tag == null)
         //    {
-        //        return new AesEncryptionResult()
+        //        return new AesDecryptionResult()
         //        {
         //            Success = false,
         //            Message = $"Authentication Tag required."
@@ -525,7 +525,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
         //    if (tag.Length != _tagBytesLength)
         //    {
-        //        return new AesEncryptionResult()
+        //        return new AesDecryptionResult()
         //        {
         //            Success = false,
         //            Message = $"Invalid tag bit size: ({(tag.Length * 8)}). Must be: ({_tagBitSize}) bits / ({_tagBytesLength}) bytes."
@@ -534,7 +534,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
         //    if (nonce == null)
         //    {
-        //        return new AesEncryptionResult()
+        //        return new AesDecryptionResult()
         //        {
         //            Success = false,
         //            Message = $"Nonce required."
@@ -543,7 +543,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
         //    if (nonce.Length != _nonceBytesLength)
         //    {
-        //        return new AesEncryptionResult()
+        //        return new AesDecryptionResult()
         //        {
         //            Success = false,
         //            Message = $"Invalid nonce bit size: ({(nonce.Length * 8)}). Must be: ({_nonceBitSize}) bits / ({_nonceBytesLength}) bytes."
@@ -552,7 +552,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
         //    if (associatedData != null && associatedData.LongLength > _maxInputAuthDataSizeBytes)
         //    {
-        //        return new AesEncryptionResult()
+        //        return new AesDecryptionResult()
         //        {
         //            Success = false,
         //            Message = $"Max. associated data length cannot be greater than {_maxInputAuthDataSizeBytes} bytes."
@@ -568,7 +568,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
         //            aesGcm.Decrypt(nonce, encryptedStringBytes, tag, decryptedData, associatedData);
         //        }
 
-        //        return new AesEncryptionResult()
+        //        return new AesDecryptionResult()
         //        {
         //            Success = true,
         //            Message = "Data succesfully decrypted.",
@@ -581,7 +581,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
         //    }
         //    catch (Exception ex)
         //    {
-        //        return new AesEncryptionResult()
+        //        return new AesDecryptionResult()
         //        {
         //            Success = false,
         //            Message = $"Error while trying to decrypt data:\n{ex.ToString()}"

--- a/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AEAD/AEAD_AES_256_GCM.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AEAD/AEAD_AES_256_GCM.cs
@@ -18,7 +18,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 {
     public class AEAD_AES_256_GCM
     {
-        #region fields
+#region fields
 
         private static readonly int _keyBitSize = 256;
         private static readonly int _keyBytesLength = (_keyBitSize / 8);
@@ -42,12 +42,12 @@ namespace CryptHash.Net.Encryption.AES.AEAD
 
         private static readonly int _iterationsForPBKDF2 = 100000;
 
-        #endregion private fields
+#endregion private fields
 
 
-        #region public methods
+#region public methods
 
-        #region string encryption
+#region string encryption
 
         public AesEncryptionResult EncryptString(string plainString, string password, string associatedDataString = null, bool appendEncryptionDataToOutputString = true)
         {
@@ -302,10 +302,10 @@ namespace CryptHash.Net.Encryption.AES.AEAD
         //    }
         //}
 
-        #endregion string encryption
+#endregion string encryption
 
 
-        #region string decryption
+#region string decryption
 
         public AesDecryptionResult DecryptString(string base64EncryptedString, string password, string associatedDataString = null, bool hasEncryptionDataAppendedInInputString = true)
         {
@@ -384,7 +384,7 @@ namespace CryptHash.Net.Encryption.AES.AEAD
             var passwordBytes = EncryptionUtils.ConvertSecureStringToByteArray(secStrPassword);
             var associatedDataBytes = (associatedDataString == null ? null : Encoding.UTF8.GetBytes(associatedDataString));
 
-            return EncryptString(encryptedStringBytes, passwordBytes, associatedDataBytes, hasEncryptionDataAppendedInInputString);
+            return DecryptString(encryptedStringBytes, passwordBytes, associatedDataBytes, hasEncryptionDataAppendedInInputString);
         }
 
         public AesDecryptionResult DecryptString(byte[] encryptedStringBytes, byte[] passwordBytes, byte[] associatedData = null, bool hasEncryptionDataAppendedInInputString = true,
@@ -589,9 +589,9 @@ namespace CryptHash.Net.Encryption.AES.AEAD
         //    }
         //}
 
-        #endregion string decryption
+#endregion string decryption
 
-        #endregion public methods
+#endregion public methods
     }
 }
 #endif

--- a/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AEAD/Base/AesGcmBase.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/AEAD/Base/AesGcmBase.cs
@@ -146,11 +146,11 @@
 //            }
 //        }
 
-//        public AesEncryptionResult Decrypt(byte[] encryptedData, byte[] key, byte[] tag, byte[] nonce, byte[] associatedData = null)
+//        public AesDecryptionResult Decrypt(byte[] encryptedData, byte[] key, byte[] tag, byte[] nonce, byte[] associatedData = null)
 //        {
 //            if (encryptedData == null || encryptedData.Length == 0)
 //            {
-//                return new AesEncryptionResult()
+//                return new AesDecryptionResult()
 //                {
 //                    Success = false,
 //                    Message = "Encrypted data cannot be null or 0 length."
@@ -159,7 +159,7 @@
 
 //            if (encryptedData.LongLength > _maxInputDataSizeBytes)
 //            {
-//                return new AesEncryptionResult()
+//                return new AesDecryptionResult()
 //                {
 //                    Success = false,
 //                    Message = $"Max. encrypted data length cannot be greater than {_maxInputDataSizeBytes} bytes."
@@ -168,7 +168,7 @@
 
 //            if (key == null)
 //            {
-//                return new AesEncryptionResult()
+//                return new AesDecryptionResult()
 //                {
 //                    Success = false,
 //                    Message = $"Key cannot be null."
@@ -177,7 +177,7 @@
 
 //            if (!_allowedKeyBitSizes.Contains((key.Length * 8)))
 //            {
-//                return new AesEncryptionResult()
+//                return new AesDecryptionResult()
 //                {
 //                    Success = false,
 //                    Message = $"Invalid key bit size: ({(key.Length * 8)}). Must be one of the following sizes: ({string.Join(", ", _allowedKeyBitSizes)})."
@@ -186,7 +186,7 @@
 
 //            if (tag == null)
 //            {
-//                return new AesEncryptionResult()
+//                return new AesDecryptionResult()
 //                {
 //                    Success = false,
 //                    Message = $"Tag cannot be null."
@@ -195,7 +195,7 @@
 
 //            if ((tag.Length * 8) != _allowedTagBitSize)
 //            {
-//                return new AesEncryptionResult()
+//                return new AesDecryptionResult()
 //                {
 //                    Success = false,
 //                    Message = $"Invalid tag bit size: ({(tag.Length * 8)}). Must be: ({_allowedTagBitSize})."
@@ -204,7 +204,7 @@
 
 //            if (nonce == null)
 //            {
-//                return new AesEncryptionResult()
+//                return new AesDecryptionResult()
 //                {
 //                    Success = false,
 //                    Message = $"Nonce cannot be null."
@@ -213,7 +213,7 @@
 
 //            if ((nonce.Length * 8) != _allowedNonceBitSize)
 //            {
-//                return new AesEncryptionResult()
+//                return new AesDecryptionResult()
 //                {
 //                    Success = false,
 //                    Message = $"Invalid nonce bit size: ({(nonce.Length * 8)}). Must be: ({_allowedNonceBitSize})."
@@ -222,7 +222,7 @@
 
 //            if (associatedData != null && associatedData.LongLength > _maxInputAuthDataSizeBytes)
 //            {
-//                return new AesEncryptionResult()
+//                return new AesDecryptionResult()
 //                {
 //                    Success = false,
 //                    Message = $"Max. associated data length cannot be greater than {_maxInputAuthDataSizeBytes} bytes."
@@ -241,7 +241,7 @@
 //                    aesGcm.Decrypt(_nonce, encryptedData, tag, decryptedData, associatedData);
 //                }
 
-//                return new AesEncryptionResult()
+//                return new AesDecryptionResult()
 //                {
 //                    Success = true,
 //                    Message = "Data succesfully decrypted.",
@@ -254,7 +254,7 @@
 //            }
 //            catch (Exception ex)
 //            {
-//                return new AesEncryptionResult()
+//                return new AesDecryptionResult()
 //                {
 //                    Success = false,
 //                    Message = $"Error while trying to decrypt data:\n{ex.ToString()}"

--- a/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/Base/AesBase.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/Base/AesBase.cs
@@ -20,7 +20,11 @@ namespace CryptHash.Net.Encryption.AES.Base
 
         public event OnEncryptionMessageHandler OnEncryptionMessage;
 
+        public event OnDecryptionMessageHandler OnDecryptionMessage;
+
         public event OnEncryptionProgressHandler OnEncryptionProgress;
+
+        public event OnDecryptionProgressHandler OnDecryptionProgress;
 
         #endregion events
 
@@ -144,12 +148,12 @@ namespace CryptHash.Net.Encryption.AES.Base
             };
         }
 
-        internal AesEncryptionResult DecryptWithMemoryStream(byte[] encryptedData, byte[] key, byte[] IV, CipherMode cipherMode = CipherMode.CBC,
+        internal AesDecryptionResult DecryptWithMemoryStream(byte[] encryptedData, byte[] key, byte[] IV, CipherMode cipherMode = CipherMode.CBC,
             PaddingMode paddingMode = PaddingMode.PKCS7)
         {
             if (encryptedData == null || encryptedData.Length == 0)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Encrypted data cannot be null or 0 bytes."
@@ -158,7 +162,7 @@ namespace CryptHash.Net.Encryption.AES.Base
 
             if (key == null)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Key cannot be null."
@@ -167,7 +171,7 @@ namespace CryptHash.Net.Encryption.AES.Base
 
             if (IV == null)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "IV cannot be null."
@@ -189,7 +193,7 @@ namespace CryptHash.Net.Encryption.AES.Base
                         aesManaged.Key = _key;
                     else
                     {
-                        return new AesEncryptionResult()
+                        return new AesDecryptionResult()
                         {
                             Success = false,
                             Message = $"Invalid key bit size ({(_key.Length * 8)})."
@@ -219,14 +223,14 @@ namespace CryptHash.Net.Encryption.AES.Base
             }
             catch (Exception ex)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Error while trying to decrypt data:\n{ex.ToString()}"
                 };
             }
 
-            return new AesEncryptionResult()
+            return new AesDecryptionResult()
             {
                 Success = true,
                 Message = "Data succesfully decrypted.",
@@ -381,12 +385,12 @@ namespace CryptHash.Net.Encryption.AES.Base
             }
         }
 
-        internal AesEncryptionResult DecryptWithFileStream(string encryptedFilePath, string decryptedFilePath, byte[] key, byte[] IV, CipherMode cipherMode = CipherMode.CBC,
+        internal AesDecryptionResult DecryptWithFileStream(string encryptedFilePath, string decryptedFilePath, byte[] key, byte[] IV, CipherMode cipherMode = CipherMode.CBC,
             PaddingMode paddingMode = PaddingMode.PKCS7, bool deleteEncryptedFile = false, int kBbufferSize = 4, long startPosition = 0, long endPosition = 0)
         {
             if (!File.Exists(encryptedFilePath))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Encrypted file \"{encryptedFilePath}\" not found."
@@ -395,7 +399,7 @@ namespace CryptHash.Net.Encryption.AES.Base
 
             if (string.IsNullOrWhiteSpace(decryptedFilePath))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Decrypted file path required."
@@ -406,7 +410,7 @@ namespace CryptHash.Net.Encryption.AES.Base
 
             if (!Directory.Exists(destinationDirectory))
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Destination directory \"{destinationDirectory}\" not found."
@@ -415,7 +419,7 @@ namespace CryptHash.Net.Encryption.AES.Base
 
             if (key == null)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "Key cannot be null."
@@ -424,7 +428,7 @@ namespace CryptHash.Net.Encryption.AES.Base
 
             if (IV == null)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = "IV cannot be null."
@@ -433,7 +437,7 @@ namespace CryptHash.Net.Encryption.AES.Base
 
             if (endPosition < startPosition)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"End position (\"{endPosition}\") cannot be less than start position (\"{startPosition}\")."
@@ -490,7 +494,7 @@ namespace CryptHash.Net.Encryption.AES.Base
                                             {
                                                 percentageDone = tmpPercentageDone;
 
-                                                RaiseOnEncryptionProgress(percentageDone, (percentageDone != 100 ? $"Decrypting ({percentageDone}%)..." : $"Decrypted ({percentageDone}%)."));
+                                                RaiseOnDecryptionProgress(percentageDone, (percentageDone != 100 ? $"Decrypting ({percentageDone}%)..." : $"Decrypted ({percentageDone}%)."));
                                             }
                                         }
                                     }
@@ -516,7 +520,7 @@ namespace CryptHash.Net.Encryption.AES.Base
                 var message = $"File \"{encryptedFilePath}\" successfully decrypted to \"{decryptedFilePath}\".";
                 message += (deleteEncryptedFile && !pathsEqual ? $"\nFile \"{encryptedFilePath}\" deleted." : "");
 
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = true,
                     Message = message,
@@ -528,7 +532,7 @@ namespace CryptHash.Net.Encryption.AES.Base
             }
             catch (Exception ex)
             {
-                return new AesEncryptionResult()
+                return new AesDecryptionResult()
                 {
                     Success = false,
                     Message = $"Error while trying to decrypt data:\n{ex.ToString()}"
@@ -546,9 +550,19 @@ namespace CryptHash.Net.Encryption.AES.Base
             OnEncryptionMessage?.Invoke(message);
         }
 
+        internal void RaiseOnDecryptionMessage(string message)
+        {
+            OnDecryptionMessage?.Invoke(message);
+        }
+
         internal void RaiseOnEncryptionProgress(int percentageDone, string message)
         {
             OnEncryptionProgress?.Invoke(percentageDone, message);
+        }
+
+        internal void RaiseOnDecryptionProgress(int percentageDone, string message)
+        {
+            OnDecryptionProgress?.Invoke(percentageDone, message);
         }
 
         #endregion private methods

--- a/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/EncryptionResults/AesDecryptionResult.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net/Encryption/AES/EncryptionResults/AesDecryptionResult.cs
@@ -9,14 +9,14 @@ using System.Security.Cryptography;
 
 namespace CryptHash.Net.Encryption.AES.EncryptionResults
 {
-    public class AesEncryptionResult
+    public class AesDecryptionResult
     {
         public bool Success { get; set; }
         public string Message { get; set; }
-        public byte[] EncryptedDataBytes { get; set; }
-        public string EncryptedDataBase64String { get; set; }
-        //public byte[] DecryptedDataBytes { get; set; }
-        //public string DecryptedDataString { get; set; }
+        //public byte[] EncryptedDataBytes { get; set; }
+        //public string EncryptedDataBase64String { get; set; }
+        public byte[] DecryptedDataBytes { get; set; }
+        public string DecryptedDataString { get; set; }
         public byte[] Key { get; set; }
         public byte[] IV { get; set; }
         public byte[] Nonce { get; set; }

--- a/src/CryptHash.Net/lib/CryptHash.Net/Encryption/Utils/EventHandlers.cs
+++ b/src/CryptHash.Net/lib/CryptHash.Net/Encryption/Utils/EventHandlers.cs
@@ -8,5 +8,9 @@ namespace CryptHash.Net.Encryption.Utils.EventHandlers
 {
     public delegate void OnEncryptionMessageHandler(string message);
 
+    public delegate void OnDecryptionMessageHandler(string message);
+
     public delegate void OnEncryptionProgressHandler(int percentageDone, string message);
+
+    public delegate void OnDecryptionProgressHandler(int percentageDone, string message);
 }


### PR DESCRIPTION
Alessandro,

I've add a AesDecryptionResult class (issue 12), renamed the inputs on the DecryptFile functions (issue 11) and fixed the typo in hasEncryptionDataAppendedInInputFile (issue 9).

I'm not sure if I've gone about doing this the right way as this is my first attempt at committing code to GitHub (or any other public/cloud repository) and creating a Pull Request as I've only used private repositories till now.

If I've done something wrong then please feel free to bring that to my attention so I can tell correct it going forward.

As I'm currently using VS 2017 and don't have .NET Standard 2.1 or .NET Core 3.0 installed I was unable to successfully build the solution, but I think I've correctly updated the code including the code which is currently commented out.

I'm also unsure how to go about running the tests in this environment as I'm used to using a build environment which builds the solution the upon commit to the repository and then runs the tests.

Les
